### PR TITLE
add capture preview layer that stays in portrait for smooth transitio…

### DIFF
--- a/LFLiveKit/LFLiveSession.h
+++ b/LFLiveKit/LFLiveSession.h
@@ -66,6 +66,7 @@ typedef NS_ENUM(NSInteger,LFLiveCaptureTypeMask) {
 @property (nonatomic, assign) BOOL running;
 
 /** The preView will show OpenGL ES view*/
+///NOPE: the preView will show the AVCaptureSession's AVCaptureVideoPreviewLayer
 @property (nonatomic, strong, null_resettable) UIView *preView;
 
 /** The captureDevicePosition control camraPosition ,default front*/
@@ -140,11 +141,18 @@ typedef NS_ENUM(NSInteger,LFLiveCaptureTypeMask) {
  */
 - (nullable instancetype)initWithAudioConfiguration:(nullable LFLiveAudioConfiguration *)audioConfiguration videoConfiguration:(nullable LFLiveVideoConfiguration *)videoConfiguration;
 
+
+- (nullable instancetype)initWithAudioConfiguration:(nullable LFLiveAudioConfiguration *)audioConfiguration
+                                 videoConfiguration:(nullable LFLiveVideoConfiguration *)videoConfiguration
+                     capturePreviewVideoOrientation:(AVCaptureVideoOrientation)capturePreviewOrientation;
+
+
 /**
  The designated initializer. Multiple instances with the same configuration will make the
  capture unstable.
  */
 - (nullable instancetype)initWithAudioConfiguration:(nullable LFLiveAudioConfiguration *)audioConfiguration videoConfiguration:(nullable LFLiveVideoConfiguration *)videoConfiguration captureType:(LFLiveCaptureTypeMask)captureType NS_DESIGNATED_INITIALIZER;
+
 
 /** The start stream .*/
 - (void)startLive:(nonnull LFLiveStreamInfo *)streamInfo;

--- a/LFLiveKit/LFLiveSession.m
+++ b/LFLiveKit/LFLiveSession.m
@@ -50,6 +50,7 @@
 /// 时间戳锁
 @property (nonatomic, strong) dispatch_semaphore_t lock;
 
+@property (nonatomic, assign) AVCaptureVideoOrientation capturePreviewVideoOrientation;
 
 @end
 
@@ -88,6 +89,17 @@
     }
     return self;
 }
+
+- (nullable instancetype)initWithAudioConfiguration:(nullable LFLiveAudioConfiguration *)audioConfiguration
+                                 videoConfiguration:(nullable LFLiveVideoConfiguration *)videoConfiguration
+                     capturePreviewVideoOrientation:(AVCaptureVideoOrientation)capturePreviewOrientation
+{
+    if (self = [self initWithAudioConfiguration:audioConfiguration videoConfiguration:videoConfiguration]) {
+        self.capturePreviewVideoOrientation = capturePreviewOrientation;
+    }
+    return self;
+}
+
 
 - (void)dealloc {
     _videoCaptureSource.running = NO;
@@ -357,7 +369,7 @@
 - (LFVideoCapture *)videoCaptureSource {
     if (!_videoCaptureSource) {
         if(self.captureType & LFLiveCaptureMaskVideo){
-            _videoCaptureSource = [[LFVideoCapture alloc] initWithVideoConfiguration:_videoConfiguration];
+            _videoCaptureSource = [[LFVideoCapture alloc] initWithVideoConfiguration:_videoConfiguration capturePreviewVideoOrientation:_capturePreviewVideoOrientation];
             _videoCaptureSource.delegate = self;
         }
     }

--- a/LFLiveKit/Vendor/GPUImage/GPUImageVideoCamera.h
+++ b/LFLiveKit/Vendor/GPUImage/GPUImageVideoCamera.h
@@ -157,6 +157,5 @@ void setColorConversion709( GLfloat conversionMatrix[9] );
 + (BOOL)isBackFacingCameraPresent;
 + (BOOL)isFrontFacingCameraPresent;
 
--(void)addCaptureVideoPreviewLayerTo:(UIView*)preView;
 
 @end

--- a/LFLiveKit/Vendor/GPUImage/GPUImageVideoCamera.h
+++ b/LFLiveKit/Vendor/GPUImage/GPUImageVideoCamera.h
@@ -69,7 +69,11 @@ void setColorConversion709( GLfloat conversionMatrix[9] );
 @property(readonly) AVCaptureDevice *inputCamera;
 
 /// This determines the rotation applied to the output image, based on the source material
+//JK: here's the rub -- what the heck is the source material?? In the camea implementation, they use a default output connection on the capture session, which means, I think, landscapeLeft, so their so-called support for 'horizontal vertical recording' I think means they allow for a default landscape orientation video to be converted to a portrait (with asepct fill!).  But allowing the source to be portrait is not possible. (Even tho that's not what we want, per se; we want a preview in portrait so we don't have to roll the UIOrientation)
 @property(readwrite, nonatomic) UIInterfaceOrientation outputImageOrientation;
+
+///NOPE: the preView will show the AVCaptureSession's AVCaptureVideoPreviewLayer in portrait orientation
+@property (nonatomic, strong, nullable) UIView *preView;
 
 /// These properties determine whether or not the two camera orientations should be mirrored. By default, both are NO.
 @property(readwrite, nonatomic) BOOL horizontallyMirrorFrontFacingCamera, horizontallyMirrorRearFacingCamera;
@@ -152,5 +156,7 @@ void setColorConversion709( GLfloat conversionMatrix[9] );
 
 + (BOOL)isBackFacingCameraPresent;
 + (BOOL)isFrontFacingCameraPresent;
+
+-(void)addCaptureVideoPreviewLayerTo:(UIView*)preView;
 
 @end

--- a/LFLiveKit/Vendor/GPUImage/GPUImageVideoCamera.m
+++ b/LFLiveKit/Vendor/GPUImage/GPUImageVideoCamera.m
@@ -236,7 +236,7 @@ void setColorConversion709( GLfloat conversionMatrix[9] )
 	{
 		[_captureSession addOutput:videoOutput];
         _outpuConnection = [videoOutput connectionWithMediaType:AVMediaTypeVideo];
-        _outpuConnection.videoOrientation = AVCaptureVideoOrientationLandscapeRight;
+        _outpuConnection.videoOrientation = AVCaptureVideoOrientationLandscapeLeft;
 	}
 	else
 	{

--- a/LFLiveKit/capture/LFVideoCapture.h
+++ b/LFLiveKit/capture/LFVideoCapture.h
@@ -30,7 +30,8 @@
 @property (nonatomic, assign) BOOL running;
 
 /** The preView will show OpenGL ES view*/
-@property (null_resettable, nonatomic, strong) UIView *preView;
+///NOPE: the preView will show the AVCaptureSession's AVCaptureVideoPreviewLayer
+@property (nonatomic, strong, nullable) UIView *preView;
 
 /** The captureDevicePosition control camraPosition ,default front*/
 @property (nonatomic, assign) AVCaptureDevicePosition captureDevicePosition;
@@ -80,5 +81,8 @@
    capture unstable.
  */
 - (nullable instancetype)initWithVideoConfiguration:(nullable LFLiveVideoConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
+
+///use this initializer to set a capture preview video orienation that is different than output video configuration's orientation
+- (nullable instancetype)initWithVideoConfiguration:(nullable LFLiveVideoConfiguration *)configuration capturePreviewVideoOrientation:(AVCaptureVideoOrientation)capturePreviewVideoOrientation;
 
 @end

--- a/LFLiveKit/capture/LFVideoCapture.m
+++ b/LFLiveKit/capture/LFVideoCapture.m
@@ -142,11 +142,7 @@
     //VEVOLIVEHACK: arg preView is always in portrait, and is used for showing the preview layer. But rendering for streaming requires gpuImageView (why??) and we set its aspect ratio to landscape, our output aspect
     
     if (self.gpuImageView.superview) [self.gpuImageView removeFromSuperview];
-//    self.gpuImageView.frame = CGRectMake(0, 0, preView.frame.size.width, preView.frame.size.height);
-    self.gpuImageView.frame = CGRectMake(0, 0, preView.frame.size.height, preView.frame.size.width);
-    
-    //DEBUG: to see text in screen, uncomment this line
-//    [preView insertSubview:self.gpuImageView atIndex:0];
+    self.gpuImageView.frame = CGRectMake(0, 0, preView.frame.size.width, preView.frame.size.height);
 }
 
 - (UIView *)preView {

--- a/LFLiveKit/configuration/LFLiveVideoConfiguration.m
+++ b/LFLiveKit/configuration/LFLiveVideoConfiguration.m
@@ -26,9 +26,9 @@
 
 + (instancetype)defaultConfigurationForQuality:(LFLiveVideoQuality)videoQuality outputImageOrientation:(UIInterfaceOrientation)outputImageOrientation {
     LFLiveVideoConfiguration *configuration = [LFLiveVideoConfiguration new];
-    [configuration updateConfigurationBasedOnVideoQuality:videoQuality];
     configuration.outputImageOrientation = outputImageOrientation;
-
+    [configuration updateConfigurationBasedOnVideoQuality:videoQuality];
+    
     return configuration;
 }
 
@@ -137,9 +137,6 @@
         default:
             break;
     }
-    
-    //VEVOLIVEHACK: does not use the autorotation feature; instead our video configuration connects two AVCaptureConnections to the AVCaptureSession in GPUImageVideoCamera: the default output connection on the session which we lock into landscapeLeft (for the front facing camera), and one for an AVCaptureVideoPreviewLayer locked in portrait for the initial video preview. LFLiveKit, tho, as designed expects to start with the front facing camera in portrait and with autorotation on -- obvious from how all the above default configurations' videoSize aspects are portrait.  So here we convert the default output connection aspect from portrait to landscape
-    self.videoSize = CGSizeMake(self.videoSize.height, self.videoSize.width);
     
     self.sessionPreset = [self supportSessionPreset:self.sessionPreset];
     self.videoMaxKeyframeInterval = self.videoFrameRate*2;

--- a/LFLiveKit/configuration/LFLiveVideoConfiguration.m
+++ b/LFLiveKit/configuration/LFLiveVideoConfiguration.m
@@ -137,6 +137,10 @@
         default:
             break;
     }
+    
+    //VEVOLIVEHACK: does not use the autorotation feature; instead our video configuration connects two AVCaptureConnections to the AVCaptureSession in GPUImageVideoCamera: the default output connection on the session which we lock into landscapeLeft (for the front facing camera), and one for an AVCaptureVideoPreviewLayer locked in portrait for the initial video preview. LFLiveKit, tho, as designed expects to start with the front facing camera in portrait and with autorotation on -- obvious from how all the above default configurations' videoSize aspects are portrait.  So here we convert the default output connection aspect from portrait to landscape
+    self.videoSize = CGSizeMake(self.videoSize.height, self.videoSize.width);
+    
     self.sessionPreset = [self supportSessionPreset:self.sessionPreset];
     self.videoMaxKeyframeInterval = self.videoFrameRate*2;
     CGSize size = self.videoSize;


### PR DESCRIPTION
…n between portrait and landscape ui orientation when starting a live stream

fixes #ios-3213

requires same named branch on iOS_Universal

LFLiveKit, when starting an AVCaptureSession, makes one one output connection to the session, which defaults to landscape.  It then has video configuration property outputImageOrientation that it transforms to using a GPU filter.  This approach doesn't work for our use case of starting the camera capture when ui is in portrait -- while LFLiveKit can transition from imageOutputOrientation portrait to landscape, it uses the GPU to do it, but so does the UI runtime to animate the UI orienation change, so the GPU output image is warped and frozen during the change.

To get around this problem, this fix adds a second output connection that only feeds a capture preview layer. More, the capture preview layer is configured with orientation portrait, and this doesn't change -- but that's what we want because during the UI transition from portrait to landscape and back again, we use the transition animation coordinatore to rotate the preview layer such that it doesn't even look like it moves.