### PR TITLE
Add logic not pause camera when Control/Notification Center

### DIFF
--- a/LFLiveKit/coder/LFHardwareVideoEncoder.m
+++ b/LFLiveKit/coder/LFHardwareVideoEncoder.m
@@ -22,6 +22,8 @@
 @property (nonatomic) NSInteger currentVideoBitRate;
 @property (nonatomic) BOOL isBackGround;
 
+@property (nonatomic, assign) BOOL fullyBackground;
+
 @end
 
 @implementation LFHardwareVideoEncoder
@@ -32,7 +34,8 @@
         NSLog(@"USE LFHardwareVideoEncoder");
         _configuration = configuration;
         [self resetCompressionSession];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(willEnterBackground:) name:UIApplicationWillResignActiveNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(willResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(willEnterForeground:) name:UIApplicationDidBecomeActiveNotification object:nil];
 #ifdef DEBUG
         enabledWriteVideoFile = NO;
@@ -124,13 +127,23 @@
 }
 
 #pragma mark -- Notification
-- (void)willEnterBackground:(NSNotification*)notification{
+
+- (void)willResignActive:(NSNotification *)notification {
+    _fullyBackground = NO;
+}
+
+- (void)didEnterBackground:(NSNotification*)notification{
+    _fullyBackground = YES;
     _isBackGround = YES;
 }
 
 - (void)willEnterForeground:(NSNotification*)notification{
-    [self resetCompressionSession];
-    _isBackGround = NO;
+    
+    if (_fullyBackground) {
+        [self resetCompressionSession];
+        _isBackGround = NO;
+    }
+    _fullyBackground = NO;
 }
 
 #pragma mark -- VideoCallBack


### PR DESCRIPTION
Should only pause capture when fully background app, not when Control
Center show up.
when control/notify center show up, app will receive
applicationWillResignActive, but no applicationDidBecomeActive. 
Add logic to check if fully background app and only pause camera and encoder when fully background app.