### PR TITLE
restore overlay

### DIFF
--- a/LFLiveKit/Vendor/GPUImage/GPUImageFilter.m
+++ b/LFLiveKit/Vendor/GPUImage/GPUImageFilter.m
@@ -344,6 +344,9 @@ NSString *const kGPUImagePassthroughFragmentShaderString = SHADER_STRING
             NSInteger indexOfObject = [targets indexOfObject:currentTarget];
             NSInteger textureIndex = [[targetTextureIndices objectAtIndex:indexOfObject] integerValue];
 
+            if ([self outputFrameSize].height > 360.0) {
+                NSLog(@"currentTarget=%@\n",currentTarget);
+            }
             [self setInputFramebufferForTarget:currentTarget atIndex:textureIndex];
             [currentTarget setInputSize:[self outputFrameSize] atIndex:textureIndex];
         }

--- a/LFLiveKit/Vendor/GPUImage/GPUImageUIElement.m
+++ b/LFLiveKit/Vendor/GPUImage/GPUImageUIElement.m
@@ -94,8 +94,8 @@
     // We've seen attached layer getting stretched when streaming from an iPhone X whose resolution is not close to 16:9.
     // The ratio of the stretch is the actual resolution devided by (16/9). In iPhone X's case it's 1.218. So in our scale, we should consider adding this to the x-axis scale factor so the output layer is still the same scale without stretching.
     CGFloat stretch = 1;
-//    if (layerPixelSize.width > layerPixelSize.height)
-//        stretch = layerPixelSize.width/layerPixelSize.height/(16.0/9.0);
+    if (layerPixelSize.width > layerPixelSize.height)
+        stretch = layerPixelSize.width/layerPixelSize.height/(16.0/9.0);
     CGContextScaleCTM(imageContext, layer.contentsScale*stretch, -layer.contentsScale);
     
     //        CGContextSetBlendMode(imageContext, kCGBlendModeCopy); // From Technical Q&A QA1708: http://developer.apple.com/library/ios/#qa/qa1708/_index.html

--- a/LFLiveKit/Vendor/GPUImage/GPUImageUIElement.m
+++ b/LFLiveKit/Vendor/GPUImage/GPUImageUIElement.m
@@ -94,8 +94,8 @@
     // We've seen attached layer getting stretched when streaming from an iPhone X whose resolution is not close to 16:9.
     // The ratio of the stretch is the actual resolution devided by (16/9). In iPhone X's case it's 1.218. So in our scale, we should consider adding this to the x-axis scale factor so the output layer is still the same scale without stretching.
     CGFloat stretch = 1;
-    if (layerPixelSize.width > layerPixelSize.height)
-        stretch = layerPixelSize.width/layerPixelSize.height/(16.0/9.0);
+//    if (layerPixelSize.width > layerPixelSize.height)
+//        stretch = layerPixelSize.width/layerPixelSize.height/(16.0/9.0);
     CGContextScaleCTM(imageContext, layer.contentsScale*stretch, -layer.contentsScale);
     
     //        CGContextSetBlendMode(imageContext, kCGBlendModeCopy); // From Technical Q&A QA1708: http://developer.apple.com/library/ios/#qa/qa1708/_index.html

--- a/LFLiveKit/Vendor/GPUImage/iOS/GPUImageView.m
+++ b/LFLiveKit/Vendor/GPUImage/iOS/GPUImageView.m
@@ -232,15 +232,18 @@
 
 - (void)recalculateViewGeometry;
 {
+    //copy current bounds since we can't access the property off the main thread
+    CGRect currentBounds = self.bounds;
+    
     runSynchronouslyOnVideoProcessingQueue(^{
         CGFloat heightScaling, widthScaling;
         
-        CGSize currentViewSize = self.bounds.size;
+        CGSize currentViewSize = currentBounds.size;
         
         //    CGFloat imageAspectRatio = inputImageSize.width / inputImageSize.height;
         //    CGFloat viewAspectRatio = currentViewSize.width / currentViewSize.height;
         
-        CGRect insetRect = AVMakeRectWithAspectRatioInsideRect(inputImageSize, self.bounds);
+        CGRect insetRect = AVMakeRectWithAspectRatioInsideRect(inputImageSize, currentBounds);
         
         switch(_fillMode)
         {
@@ -261,6 +264,10 @@
                 heightScaling = currentViewSize.width / insetRect.size.width;
             }; break;
         }
+        
+//        fprintf(stdout,"[GPUImageView/recalculateViewGeometry]..inputImageSize=%fx%f\n",inputImageSize.width,inputImageSize.height);
+//        fprintf(stdout,"[GPUImageView/recalculateViewGeometry]..insetRect=(%f,%f) %fx%f\n",insetRect.origin.x,insetRect.origin.y,insetRect.size.width,insetRect.size.height);
+//        fprintf(stdout,"[GPUImageView/recalculateViewGeometry]..widthScaling=%f, heightScaling=%f\n",widthScaling,heightScaling);
         
         imageVertices[0] = -widthScaling;
         imageVertices[1] = -heightScaling;

--- a/LFLiveKit/capture/LFVideoCapture.m
+++ b/LFLiveKit/capture/LFVideoCapture.m
@@ -145,7 +145,7 @@
     //VEVOLIVEHACK: arg preView is always in portrait, and is used for showing the preview layer. But rendering for streaming requires gpuImageView (why??) and we set its aspect ratio to landscape, our output aspect
     
     if (self.gpuImageView.superview) [self.gpuImageView removeFromSuperview];
-    self.gpuImageView.frame = CGRectMake(0, 0, preView.frame.size.width, preView.frame.size.height);
+    self.gpuImageView.frame = CGRectMake(0, 0, preView.frame.size.height, preView.frame.size.width);
 }
 
 - (UIView *)preView {
@@ -250,12 +250,14 @@
 }
 
 - (void)setWatermarkView:(UIView *)watermarkView{
+    fprintf(stdout,"[LFVideoCapture/setWatermarkView:]...\n");
     if(_watermarkView && _watermarkView.superview){
         [_watermarkView removeFromSuperview];
         _watermarkView = nil;
     }
     _watermarkView = watermarkView;
     self.blendFilter.mix = watermarkView.alpha;
+    self.waterMarkContentView.frame = _watermarkView.frame;
     [self.waterMarkContentView addSubview:_watermarkView];
     [self reloadFilter];
 }
@@ -283,7 +285,8 @@
         _waterMarkContentView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     }
     
-    _waterMarkContentView.frame = [[UIScreen mainScreen] bounds];
+//    _waterMarkContentView.frame = CGRectMake(0, 0, self.configuration.videoSize.width, self.configuration.videoSize.height);
+//    _waterMarkContentView.frame = [[UIScreen mainScreen] bounds];
     
     return _waterMarkContentView;
 }
@@ -291,7 +294,7 @@
 - (GPUImageView *)gpuImageView{
     if(!_gpuImageView){
         _gpuImageView = [[GPUImageView alloc] initWithFrame:[UIScreen mainScreen].bounds];
-        [_gpuImageView setFillMode:kGPUImageFillModePreserveAspectRatio];
+        [_gpuImageView setFillMode:kGPUImageFillModePreserveAspectRatioAndFill];
         [_gpuImageView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
     }
     return _gpuImageView;

--- a/LFLiveKit/capture/LFVideoCapture.m
+++ b/LFLiveKit/capture/LFVideoCapture.m
@@ -366,7 +366,6 @@
         [self.videoCamera addTarget:self.filter];
     }
     
-    
     // 添加水印
     if (self.watermarkView) {
         [self.filter addTarget:self.blendFilter];
@@ -380,7 +379,7 @@
         
         [self.blendFilter addTarget:self.output];
 
-      [self.filter addTarget:self.gpuImageView];
+        [self.filter addTarget:self.gpuImageView];
 //        [self.blendFilter addTarget:self.gpuImageView];
         [self.uiElementInput update];
     } else {


### PR DESCRIPTION
Fixes: 
-gpuImageView was being initialized to a vertical portrait orientation, which in fact it only appears in landscape (for now). 
-it's fill mode was not set to fill, which did not match everything else 
-sets watermarkContentView to the size of the watermarkView 
-a small tweak to capture UIView bounds before dispatching async off the main thread