### PR TITLE
Fixes ios-3435

### DIFF
--- a/LFLiveKit/Vendor/GPUImage/GPUImageUIElement.m
+++ b/LFLiveKit/Vendor/GPUImage/GPUImageUIElement.m
@@ -91,12 +91,8 @@
     //    CGContextRotateCTM(imageContext, M_PI_2);
     CGContextTranslateCTM(imageContext, 0.0f, layerPixelSize.height);
     
-    // We've seen attached layer getting stretched when streaming from an iPhone X whose resolution is not close to 16:9.
-    // The ratio of the stretch is the actual resolution devided by (16/9). In iPhone X's case it's 1.218. So in our scale, we should consider adding this to the x-axis scale factor so the output layer is still the same scale without stretching.
-    CGFloat stretch = 1;
-    if (layerPixelSize.width > layerPixelSize.height)
-        stretch = layerPixelSize.width/layerPixelSize.height/(16.0/9.0);
-    CGContextScaleCTM(imageContext, layer.contentsScale*stretch, -layer.contentsScale);
+    //invert y-axis to bring view into view
+    CGContextScaleCTM(imageContext, layer.contentsScale, -layer.contentsScale);
     
     //        CGContextSetBlendMode(imageContext, kCGBlendModeCopy); // From Technical Q&A QA1708: http://developer.apple.com/library/ios/#qa/qa1708/_index.html
     

--- a/LFLiveKit/Vendor/pili-librtmp/rtmp.c
+++ b/LFLiveKit/Vendor/pili-librtmp/rtmp.c
@@ -126,6 +126,9 @@ static int clk_tck;
 #include "handshake.h"
 #endif
 
+
+//static int gWriteCounter = 0;
+
 uint32_t
     PILI_RTMP_GetTime() {
 #ifdef _DEBUG
@@ -942,6 +945,8 @@ int PILI_RTMP_Connect(PILI_RTMP *r, PILI_RTMPPacket *cp, RTMPError *error) {
     struct PILI_CONNECTION_TIME conn_time;
     if (!r->Link.hostname.av_len)
         return FALSE;
+    
+//    gWriteCounter = 0;
 
     struct addrinfo hints = {0}, *ai, *cur_ai;
     hints.ai_family = PF_UNSPEC;
@@ -1405,12 +1410,13 @@ static int
 }
 
 static int
-    WriteN(PILI_RTMP *r, const char *buffer, int n, RTMPError *error) {
+WriteN(PILI_RTMP *r, const char *buffer, int n, RTMPError *error) {
     const char *ptr = buffer;
+    
 #ifdef CRYPTO
     char *encrypted = 0;
     char buf[RTMP_BUFFER_CACHE_SIZE];
-
+    
     if (r->Link.rc4keyOut) {
         if (n > sizeof(buf))
             encrypted = (char *)malloc(n);
@@ -1420,15 +1426,26 @@ static int
         RC4_encrypt2(r->Link.rc4keyOut, n, buffer, ptr);
     }
 #endif
-
+    
     while (n > 0) {
         int nBytes;
-
-        if (r->Link.protocol & RTMP_FEATURE_HTTP)
-            nBytes = HTTP_Post(r, RTMPT_SEND, ptr, n);
-        else
-            nBytes = PILI_RTMPSockBuf_Send(&r->m_sb, ptr, n);
-        /*RTMP_Log(RTMP_LOGDEBUG, "%s: %d\n", __FUNCTION__, nBytes); */
+        
+//        if (gWriteCounter == 60000) {
+//            nBytes = -1;
+//        }
+//        else if (gWriteCounter > 60000) {
+//            nBytes = 0;
+//            break;
+//        }
+//        else {
+            if (r->Link.protocol & RTMP_FEATURE_HTTP)
+                nBytes = HTTP_Post(r, RTMPT_SEND, ptr, n);
+            else
+                nBytes = PILI_RTMPSockBuf_Send(&r->m_sb, ptr, n);
+            /*RTMP_Log(RTMP_LOGDEBUG, "%s: %d\n", __FUNCTION__, nBytes); */
+//        }
+        
+//        ++gWriteCounter;
 
         if (nBytes < 0) {
             int sockerr = GetSockError();


### PR DESCRIPTION
requires same named branch in iOS_Universal

The 3435 issue was that overlay content extended beneath the notch and off the bottom of the frame in the player on iPhoneX when in landscape.  That fix adjusted margins, but also changed the way the overlay view is generated that no longer requires the scaling, so this commit simply removes the scaling.

There is also in this commit some commented out debug code that was put in place to simulate a lost connection to Gozer so as to ensure correct handling when the connection is lost, or if Gozer itself closes the socket because it suffered an internal error, recovery of which required the streamer to initiate a new session.  Did not want to remove it just yet.